### PR TITLE
Fix for broken events in <TouchableWithoutFeedback>

### DIFF
--- a/src/components/MultiBarToggle.js
+++ b/src/components/MultiBarToggle.js
@@ -182,18 +182,20 @@ class MultiBarToggle extends Component {
                 <TouchableWithoutFeedback
                     onPress={this.togglePressed}
                 >
-                    <Animated.View style={[Styles.toggleButton, {
-                        transform: [
-                            {rotate: activationRotate},
-                            {scale: activationScale}
-                        ],
-                        width: toggleSize,
-                        height: toggleSize,
-                        borderRadius: toggleSize / 2,
-                        backgroundColor: toggleColor
-                    }]}>
-                        {icon}
-                    </Animated.View>
+					<View>
+						<Animated.View style={[Styles.toggleButton, {
+							transform: [
+								{rotate: activationRotate},
+								{scale: activationScale}
+							],
+							width: toggleSize,
+							height: toggleSize,
+							borderRadius: toggleSize / 2,
+							backgroundColor: toggleColor
+						}]}>
+							{icon}
+						</Animated.View>
+					</View>
                 </TouchableWithoutFeedback>
             </View>
         );


### PR DESCRIPTION
The `<TouchableWithoutFeedback>` element can accept only one child element (see [documentation](https://facebook.github.io/react-native/docs/touchablewithoutfeedback)) because of which the events `onPress`, `onPressOut`, etc. not always performed. The optimal solution to this problem is the conclusion of all elements (including custom ones) in the standard `<View>` element. This solves problems with triggering events on different versions of React Native (see similar [problem](https://github.com/facebook/react-native/issues/10180#issuecomment-298375648)).