### PR TITLE
Avoiding hidden buttons to go off the plus button when a label is provided in Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-multibar",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "MultiBar is a TabBar component with an advanced button to make extra actions.",
   "main": "index.js",
   "scripts": {

--- a/src/components/MultiBarToggle.js
+++ b/src/components/MultiBarToggle.js
@@ -84,6 +84,10 @@ class MultiBarToggle extends Component {
             actionExpandingAngle
         } = this.props;
 
+        const {
+            active
+        } = this.state;
+
         const STEP = actionExpandingAngle / routes.length;
 
         return routes.map((route, i) => {
@@ -134,7 +138,7 @@ class MultiBarToggle extends Component {
                     >
                         {route.icon}
                     </AnimatedTouchable>
-                    {route.buttonlabel && (
+                    {route.buttonlabel && active && (
                         <Text style={[Styles.actionContent, Styles.actionContentLabel]}>
                             {route.buttonlabel}
                         </Text>

--- a/src/components/MultiBarToggle.js
+++ b/src/components/MultiBarToggle.js
@@ -35,7 +35,8 @@ class MultiBarToggle extends Component {
 
         if (route.routeName) {
             setTimeout(() => this.props.navigation.navigate({
-                routeName: route.routeName
+                routeName: route.routeName,
+                params: route.params
             }), navigationDelay);
         }
 
@@ -279,7 +280,8 @@ MultiBarToggle.propTypes = {
         routeName: PropTypes.string,
         color: PropTypes.string,
         icon: PropTypes.node,
-        buttonlabel: PropTypes.string
+        buttonlabel: PropTypes.string,
+        params: PropTypes.object
     })),
     actionSize: PropTypes.number,
     actionVibration: PropTypes.bool,


### PR DESCRIPTION
I noticed that when I provide a label for the hidden button at the first render they go off the plus circle in Android. To avoid that I make sure that the label is rendered only if the toggle is active, so that solves the problem.

<img src="https://user-images.githubusercontent.com/21176544/61863824-a5d2d880-aed0-11e9-818d-7ff4591184f8.jpg" width="200" alt="overlay_preview" />
